### PR TITLE
feat: CUDA & ROCm enabled docker images for graxil

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   docker-build:
     name: docker build
+    strategy:
+      matrix:
+        gpu-platform: [rocm, cuda]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -24,9 +27,9 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: docker/Dockerfile.cuda
+          file: docker/Dockerfile.${{ matrix.gpu-platform }}
           push: false
-          tags: graxil-cuda:${{ steps.vars.outputs.sha_short }}
+          tags: graxil-${{ matrix.gpu-platform }}:${{ steps.vars.outputs.sha_short }}
           # NOTE(canardleteer): Since we don't really push or publish this (or
           #                     do multi-layer builds), we don't enable these
           #                     extra steps that are more useful once that's the

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,42 @@
+name: docker build
+
+on:
+  pull_request:
+    branches: [ "main" ]
+  push:
+    branches: [ "main" ]
+
+jobs:
+  docker-build:
+    name: docker build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: setup buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Set SHA_SHORT for commit
+        id: vars
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: "build target: graxil-cuda"
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile.cuda
+          push: false
+          tags: graxil-cuda:${{ steps.vars.outputs.sha_short }}
+          # NOTE(canardleteer): Since we don't really push or publish this (or
+          #                     do multi-layer builds), we don't enable these
+          #                     extra steps that are more useful once that's the
+          #                     case.
+          # provenance: mode=max
+          # sbom: true
+          # load: true
+          # cache-from: type=gha
+          # cache-to: type=gha,mode=max
+
+      # NOTE(canardleteer): Unfortunately, there are no GPU runners available
+      #                     with GitHub actions to test anything more than a
+      #                     successful build process.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ cargo build --release --features gpu
 cargo build --release --features hybrid
 ```
 
+- Docker images can be built as well, via [these instructions](./docker/README.md).
+
 ## ⚠️ Important Notes
 
 - **Hybrid Feature**: Currently WIP - it builds but runs either GPU OR CPU mining, not both simultaneously

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ cargo build --release --features gpu
 cargo build --release --features hybrid
 ```
 
-- Docker images can be built as well, via [these instructions](./docker/README.md).
+- Docker images (CUDA & ROCm) can be built as well, via [these instructions](./docker/README.md).
 
 ## ⚠️ Important Notes
 

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -1,0 +1,62 @@
+# The CUDA version matters to some degree, and must at least work with the
+# driver used on the container host.
+ARG BASE_CUDA_DEV_CONTAINER=nvidia/cuda:12.8.1-devel-ubuntu24.04
+ARG BASE_CUDA_RUN_CONTAINER=nvidia/cuda:12.8.1-runtime-ubuntu24.04
+
+# `release` or `debug`
+ARG RUST_TARGET_TYPE="release"
+
+# NOTE(canardleteer): It's easier to install Rust on a CUDA image, than it is
+#                     to install CUDA on a Rust image.
+FROM $BASE_CUDA_DEV_CONTAINER AS build
+ARG RUST_TARGET_TYPE
+
+# Install required Ubuntu packages
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt update && \
+    apt install -y --no-install-recommends nvidia-opencl-dev curl && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN useradd -ms /bin/bash graxil
+USER graxil
+WORKDIR /home/graxil
+
+# Grab the "latest" Rust.
+#
+# NOTE(canardleteer): I'm a little confused by the `rust-toolchain` file in this
+#                     repo, AFAIK, it's similar to the `cargo` supported
+#                     `rust-toolchain.toml` file, but I'm not attempting to
+#                     capture changes to the CI build system in this PR.
+ADD --chmod=755 https://sh.rustup.rs /home/graxil/rustup.sh
+RUN ./rustup.sh -y
+ENV PATH="/home/graxil/.cargo/bin:${PATH}"
+
+# Cache dependency changes first.
+COPY Cargo.toml Cargo.lock ./
+RUN cargo fetch
+
+# Then cache whatever else is required via an include.
+COPY src ./src
+COPY kernels ./kernels
+COPY ./log4rs_sample.yml ./
+
+# The default `hybrid` feature should pick up the `nvidia-opencl-dev` just fine.
+RUN cargo build --$RUST_TARGET_TYPE
+
+FROM $BASE_CUDA_RUN_CONTAINER AS runtime
+
+ARG RUST_TARGET_TYPE
+
+RUN apt update && \
+    apt install -y --no-install-recommends pocl-opencl-icd clinfo && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /etc/OpenCL/vendors && \
+    echo "libnvidia-opencl.so.1" > /etc/OpenCL/vendors/nvidia.icd
+
+RUN useradd -ms /bin/bash graxil
+USER graxil
+WORKDIR /home/graxil
+
+COPY --from=build /home/graxil/target/$RUST_TARGET_TYPE/graxil /home/graxil/target/$RUST_TARGET_TYPE/gpu_test ./
+ENTRYPOINT [ "./graxil" ]

--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -1,0 +1,62 @@
+# The ROCm version matters to some degree, and must at least work with the
+# driver used on the container host.
+ARG BASE_ROCM_DEV_CONTAINER=rocm/dev-ubuntu-24.04:7.1.1
+ARG BASE_ROCM_RUN_CONTAINER=rocm/dev-ubuntu-24.04:7.1.1
+
+# `release` or `debug`
+ARG RUST_TARGET_TYPE="release"
+
+FROM $BASE_ROCM_DEV_CONTAINER AS build
+ARG RUST_TARGET_TYPE
+
+# Install required Ubuntu packages
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt update && \
+    apt install -y --no-install-recommends rocm-opencl-dev curl && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN useradd -ms /bin/bash graxil
+USER graxil
+WORKDIR /home/graxil
+
+# Grab the "latest" Rust.
+#
+# NOTE(canardleteer): I'm a little confused by the `rust-toolchain` file in this
+#                     repo, AFAIK, it's similar to the `cargo` supported
+#                     `rust-toolchain.toml` file, but I'm not attempting to
+#                     capture changes to the CI build system in this PR.
+ADD --chmod=755 https://sh.rustup.rs /home/graxil/rustup.sh
+RUN ./rustup.sh -y
+ENV PATH="/home/graxil/.cargo/bin:${PATH}"
+
+# Cache dependency changes first.
+COPY Cargo.toml Cargo.lock ./
+RUN cargo fetch
+
+# Then cache whatever else is required via an include.
+COPY src ./src
+COPY kernels ./kernels
+COPY ./log4rs_sample.yml ./
+
+RUN cargo build --$RUST_TARGET_TYPE
+
+FROM $BASE_ROCM_RUN_CONTAINER AS runtime
+
+ARG RUST_TARGET_TYPE
+
+RUN apt update && \
+    apt install -y --no-install-recommends rocm-opencl-runtime clinfo && \
+    rm -rf /var/lib/apt/lists/*
+
+###############################################################################
+# FIXME(canardleteer): The ROCm user/group story to run unprivileged isn't all
+#                      that well scaffolded out. We will just run as root for
+#                      now.
+#
+# RUN useradd -ms /bin/bash graxil && sudo usermod -a -G video,render graxil
+# USER graxil
+###############################################################################
+WORKDIR /home/graxil
+
+COPY --from=build /home/graxil/target/$RUST_TARGET_TYPE/graxil /home/graxil/target/$RUST_TARGET_TYPE/gpu_test ./
+ENTRYPOINT [ "./graxil" ]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,31 @@
+# `graxil` in Docker
+
+## NVIDIA Image
+
+### Requirements
+
+- [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)
+
+### Building
+
+```shell
+docker build -t graxil-cuda:latest -f docker/Dockerfile.cuda .
+```
+
+The following 3 build arguments are exposed for convenience:
+
+- `BASE_CUDA_DEV_CONTAINER`
+- `BASE_CUDA_RUN_CONTAINER`
+- `RUST_TARGET_TYPE` (`debug` or `release`)
+
+### Running
+
+Assuming you want all GPUs:
+
+```shell
+docker run -it --rm --gpus=all graxil-cuda:latest --help
+```
+
+## ROCm Image
+
+Currently not provided.

--- a/docker/README.md
+++ b/docker/README.md
@@ -23,9 +23,35 @@ The following 3 build arguments are exposed for convenience:
 Assuming you want all GPUs:
 
 ```shell
-docker run -it --rm --gpus=all graxil-cuda:latest --help
+docker run --name cuda0 -it --rm --gpus=all graxil-cuda:latest --help
 ```
 
 ## ROCm Image
 
-Currently not provided.
+- [ROCm Docker Documentation](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/how-to/docker.html)
+- The image currently runs as `root`, couldn't really find any way around that
+  without bolting the image to the container host's setup.
+  - Updated information is welcome here.
+- At the moment, `graxil` does not support `rocm-smi` to capture stats, so will
+  do GPU Mining, but report as "no-GPU." You can monitor stats with `rocm-smi`
+  manually to confirm usage.
+
+Of note, please decide for yourself if `--security-opt seccomp=unconfined` is for you.
+
+### Building
+
+The following 3 build arguments are exposed for convenience:
+
+- `BASE_ROCM_DEV_CONTAINER`
+- `BASE_ROCM_RUN_CONTAINER`
+- `RUST_TARGET_TYPE` (`debug` or `release`)
+
+```shell
+docker build -t graxil-rocm:latest -f docker/Dockerfile.rocm .
+```
+
+### Running
+
+```shell
+docker run --name rocm0 --device /dev/kfd --device /dev/dri graxil-rocm:latest --help
+```


### PR DESCRIPTION
Generally opens up the path of using graxil in a containerized environment.

Includes a Gitlab Action to test that builds work, but does not push or publish any images.

Description
---
Adds a Dockerfile for a CUDA enabled container to run `graxil` in a containerized environment.

Motivation and Context
---
Testing & deploying things gets a whole lot easier for GPU resources with containerization. Doors open.

How Has This Been Tested?
---
- I've mined some shares with it inside the CUDA container runtime (5070 & 5070 Ti).
- ROCm testing was done similarly against a `AMD Ryzen 5 PRO 5650U`, which is all I have with ROCm support.

What process can a PR reviewer use to test or verify this change?
---
Following the instructions in `docker/README.md` will allow for validation, otherwise the Gitlab Action should be sufficient to confirm it builds.

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
